### PR TITLE
Fix: Refactor auth flow to fix navigation error on login

### DIFF
--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -5,17 +5,22 @@ import { AuthStack } from './AuthStack';
 import { MainStack } from './MainStack';
 import { View, ActivityIndicator } from 'react-native';
 import { useTheme } from '../hooks/useTheme';
+import { useSelector, useDispatch } from 'react-redux';
+import { selectToken, setToken } from '../store/authSlice';
 
 export const RootNavigator: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
-  const [token, setToken] = useState<string | null>(null);
+  const token = useSelector(selectToken);
+  const dispatch = useDispatch();
   const { colors } = useTheme();
 
   useEffect(() => {
     const checkToken = async () => {
       try {
         const storedToken = await AsyncStorage.getItem('token');
-        setToken(storedToken);
+        if (storedToken) {
+          dispatch(setToken(storedToken));
+        }
       } catch (error) {
         console.error('Failed to fetch token from storage', error);
       } finally {
@@ -24,7 +29,7 @@ export const RootNavigator: React.FC = () => {
     };
 
     checkToken();
-  }, []);
+  }, [dispatch]);
 
   if (isLoading) {
     return (

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -7,26 +7,22 @@ import { TextInput } from '../components/TextInput';
 import { useLoginMutation } from '../services/api';
 import { styles } from '../styles/LoginScreen.style';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '../hooks/useTheme';
+import { useDispatch } from 'react-redux';
+import { setToken } from '../store/authSlice';
 
 export const LoginScreen: React.FC = () => {
   const [email, setEmail] = useState('george.bluth@reqres.in');
   const [password, setPassword] = useState('Developer19');
   const [login, { isLoading, error }] = useLoginMutation();
-  const navigation = useNavigation();
+  const dispatch = useDispatch();
   const { colors } = useTheme();
 
   const handleLogin = async () => {
     try {
       const { token } = await login({ email, password }).unwrap();
       await AsyncStorage.setItem('token', token);
-      // This is not the ideal way to navigate, we will fix this later
-      // by using a navigation service.
-      navigation.reset({
-        index: 0,
-        routes: [{ name: 'UserList' }],
-      });
+      dispatch(setToken(token));
     } catch (err) {
       console.error('Failed to login:', err);
     }

--- a/src/store/authSlice.ts
+++ b/src/store/authSlice.ts
@@ -1,0 +1,29 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { RootState } from './store';
+
+interface AuthState {
+  token: string | null;
+}
+
+const initialState: AuthState = {
+  token: null,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setToken: (state, action: PayloadAction<string>) => {
+      state.token = action.payload;
+    },
+    clearToken: (state) => {
+      state.token = null;
+    },
+  },
+});
+
+export const { setToken, clearToken } = authSlice.actions;
+
+export const selectToken = (state: RootState) => state.auth.token;
+
+export default authSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { api } from '../services/api';
+import authReducer from './authSlice';
 
 export const store = configureStore({
   reducer: {
     [api.reducerPath]: api.reducer,
+    auth: authReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(api.middleware),


### PR DESCRIPTION
This commit refactors the authentication flow to use Redux for state management, which resolves a navigation error that occurred on login.

The error "The action 'RESET' with payload ... was not handled by any navigator" was caused by an incorrect attempt to navigate from the `AuthStack` to a screen in the `MainStack`.

The following changes were made:
- A new `authSlice` was created to manage the authentication token in the Redux store.
- The `RootNavigator` was updated to listen to the Redux store and automatically switch between the `AuthStack` and `MainStack` based on the authentication state.
- The `LoginScreen` was updated to dispatch a Redux action to set the token upon successful login, instead of making a direct navigation call.